### PR TITLE
Fix : model

### DIFF
--- a/Backend/src/services/ai.service.js
+++ b/Backend/src/services/ai.service.js
@@ -12,7 +12,7 @@ async function generateContent(code) {
     
     // FORCE Gemini to output strict, machine-readable JSON
     const model = genAI.getGenerativeModel({ 
-        model: "gemini-2.5-pro",
+        model: "gemini-2.5-flash",
         generationConfig: {
             responseMimeType: "application/json",
         }


### PR DESCRIPTION
This pull request makes a small update to the AI service configuration by switching the Gemini model used for content generation from "gemini-2.5-pro" to "gemini-2.5-flash".

* Changed the `model` parameter in the `genAI.getGenerativeModel` call from `"gemini-2.5-pro"` to `"gemini-2.5-flash"` in `ai.service.js`, which may affect performance or cost characteristics.